### PR TITLE
[20기 노선경] Add : 로그인, 회원가입, 로그아웃 구현 및 네브바에 유저정보 나타내기

### DIFF
--- a/public/data/User/UserData.json
+++ b/public/data/User/UserData.json
@@ -1,1 +1,13 @@
-[]
+{
+  "status": "SUCCESS",
+  "data": {
+    "user": {
+      "id": 1,
+      "username": "테스트",
+      "introduction": null,
+      "email": "test@gmail.com",
+      "profile_image_url": "",
+      "kakao_id": null
+    }
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -10,6 +10,10 @@
       integrity="sha384-SZXxX4whJ79/gErwcOYf+zWLeJdY/qpuqC4cAa9rOGUstPomtqpuNWT9wdPEn2fk"
       crossorigin="anonymous"
     />
+    <script src="https://developers.kakao.com/sdk/js/kakao.js"></script>
+    <script>
+      Kakao.init('29c09ee31edbbbf67ee9abc6f597bcd9');
+    </script>
     <title>tteokbok</title>
   </head>
   <body>

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -2,6 +2,9 @@ import React from 'react';
 import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
 import Nav from './components/Nav/Nav';
 import Main from './pages/Main/Main';
+import Join from './pages/Join/Join';
+import Login from './pages/Login/Login';
+import CreateAccount from './pages/Join/CreateAccount';
 
 const Routes = () => {
   return (
@@ -9,6 +12,9 @@ const Routes = () => {
       <Nav />
       <Switch>
         <Route exact path="/" component={Main} />
+        <Route exact path="/signup" component={Join} />
+        <Route exact path="/signin" component={Login} />
+        <Route exact path="/createAccount" component={CreateAccount} />
       </Switch>
     </Router>
   );

--- a/src/components/AccountContainer/AccountContainer.js
+++ b/src/components/AccountContainer/AccountContainer.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import TextLink from './components/TextLink';
+import SocialBtnGroup from './components/SocialBtnGroup';
+import Divider from './components/Divider';
+import Title from './components/Title';
+import Container from './components/Container';
+
+function AccountContainer({ children, type }) {
+  return (
+    <Container>
+      <Title title={AccountData[type].title} />
+      <SocialBtnGroup text={AccountData[type].title} />
+      <Divider />
+      {children}
+      <TextLink type={AccountData[type]} />
+    </Container>
+  );
+}
+
+export default AccountContainer;
+
+const AccountData = {
+  signin: {
+    title: '가입하기',
+    desc: '이미 텀블벅 계정이 있으신가요?',
+    url: 'signin',
+    link: '기존계정으로 로그인하기',
+  },
+  signup: {
+    title: '로그인하기',
+    desc: '아직 텀블벅 계정이 없으신가요?',
+    url: 'signup',
+    link: '가입하기',
+  },
+};

--- a/src/components/AccountContainer/components/Container.js
+++ b/src/components/AccountContainer/components/Container.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import styled from 'styled-components';
+import Footer from './Footer';
+
+function Container({ children }) {
+  return (
+    <>
+      <StyledAccountContainer>{children}</StyledAccountContainer>
+      <Footer />
+    </>
+  );
+}
+
+const StyledAccountContainer = styled.main`
+  text-align: center;
+  padding: 32px 16px 0px 16px;
+  margin: 0px 0px 34px;
+
+  ${({ theme }) => theme.tablet` 
+    width: 400px;
+    padding: 2rem;
+    margin: 130px auto 12px;
+    border-radius: 5px;
+    border: 1px solid rgb(228, 228, 228);
+  `};
+
+  a {
+    color: rgb(39, 163, 255);
+    text-decoration: underline;
+  }
+`;
+
+export default Container;

--- a/src/components/AccountContainer/components/Divider.js
+++ b/src/components/AccountContainer/components/Divider.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import styled from 'styled-components';
+
+function Divider() {
+  return (
+    <StyledDivider>
+      <span>또는</span>
+    </StyledDivider>
+  );
+}
+
+const StyledDivider = styled.div`
+  padding: 10px 0px;
+  overflow: hidden;
+  text-align: center;
+
+  span {
+    position: relative;
+    padding: 16px;
+    color: rgb(158, 158, 158);
+    font-size: 13px;
+
+    &::before {
+      content: '';
+      position: absolute;
+      border-bottom: 1px solid rgb(228, 228, 228);
+      top: 50%;
+      right: 100%;
+      width: 5000px;
+    }
+
+    &::after {
+      content: '';
+      position: absolute;
+      border-bottom: 1px solid rgb(228, 228, 228);
+      top: 50%;
+      left: 100%;
+      width: 5000px;
+    }
+  }
+`;
+
+export default Divider;

--- a/src/components/AccountContainer/components/Footer.js
+++ b/src/components/AccountContainer/components/Footer.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import styled from 'styled-components';
+
+function Footer() {
+  return <StyledFooter>© 2021 Tteokbok:) Inc.</StyledFooter>;
+}
+
+const StyledFooter = styled.div`
+  font-size: 11.2px;
+  color: rgb(117, 117, 117);
+  text-align: center;
+  padding: 0px 0px 20px;
+`;
+
+export default Footer;

--- a/src/components/AccountContainer/components/Input.js
+++ b/src/components/AccountContainer/components/Input.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import styled from 'styled-components';
+
+function Input({ ...rest }) {
+  return <StyledInput {...rest} />;
+}
+
+const StyledInput = styled.input`
+  width: 100%;
+  height: 48px;
+  outline: none;
+  border: 1px solid rgb(230, 230, 230);
+  border-radius: 4px;
+  color: black;
+  cursor: pointer;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  margin-bottom: 0.6rem;
+`;
+
+export default Input;

--- a/src/components/AccountContainer/components/Section.js
+++ b/src/components/AccountContainer/components/Section.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import styled, { css } from 'styled-components/macro';
+
+function Section({ children, title, input, checkbox }) {
+  return (
+    <StyledSection input={input} checkbox={checkbox}>
+      <label>{title}</label>
+      {children}
+    </StyledSection>
+  );
+}
+
+const typeStyles = css`
+  ${props =>
+    (props.input &&
+      css`
+        ${({ theme }) => theme.flexColumnSet('center', 'flex-start')};
+        margin-bottom: 1rem;
+        label {
+          margin-bottom: 10px;
+        }
+      `) ||
+    (props.checkbox &&
+      css`
+        color: #3d3d3d;
+        ${({ theme }) => theme.flexSet('flex-start', 'center')};
+        & > label {
+          order: 1;
+          margin-left: 1rem;
+        }
+      `)};
+`;
+
+const StyledSection = styled.div`
+  ${typeStyles}
+`;
+
+export default Section;

--- a/src/components/AccountContainer/components/SocialBtnGroup.js
+++ b/src/components/AccountContainer/components/SocialBtnGroup.js
@@ -1,0 +1,88 @@
+import React from 'react';
+import Button from '../../Button/Button';
+import styled from 'styled-components';
+import { useHistory } from 'react-router-dom';
+import { API } from '../../../config';
+
+function SocialBtnGroup({ text }) {
+  const history = useHistory();
+
+  const handleKakaoLogin = () => {
+    const { Kakao } = window;
+    Kakao.Auth.login({
+      scope: 'account_email, gender, birthday',
+      success: res => {
+        fetch(`${API.KAKAO}`, {
+          method: 'POST',
+          body: JSON.stringify({ access_token: res.access_token }),
+        })
+          .then(res => res.json())
+          .then(res => {
+            if (res.status === 'SUCCESS') {
+              localStorage.setItem('token', res.data.token);
+              Kakao.Auth.logout();
+              history.push('/');
+              alert('카카오톡으로 로그인 성공했습니다.');
+            } else if (res.status === 'DUPLICATED_ENTRY_ERROR') {
+              alert('이미 가입된 이메일입니다.');
+            } else if (
+              res.status === 'TIMEOUT_ERROR' ||
+              res.status === 'CONNECTION_ERROR'
+            ) {
+              alert(
+                '카카오 계정으로 로그인 중 문제가 발생했습니다.',
+                res.message
+              );
+            }
+          });
+      },
+      fail: error => {
+        alert(JSON.stringify(error));
+      },
+    });
+  };
+
+  return (
+    <SocialLogin>
+      <AccountButton fullWidth>
+        <i className="fab fa-facebook"></i>
+        페이스북 아이디로 {text}
+      </AccountButton>
+      <AccountButton fullWidth onClick={handleKakaoLogin}>
+        <i className="fas fa-comment-dots"></i>
+        카카오 아이디로 {text}
+      </AccountButton>
+      <AccountButton fullWidth>
+        <i className="fab fa-apple"></i>
+        애플 아이디로 {text}
+      </AccountButton>
+    </SocialLogin>
+  );
+}
+
+const SocialLogin = styled.div`
+  ${({ theme }) => theme.flexColumnSet};
+  i {
+    font-size: 1.4rem;
+    margin-right: 6px;
+  }
+
+  [class$='facebook'] {
+    color: #1877f2;
+  }
+
+  [class$='dots'] {
+    color: #391a1c;
+  }
+
+  [class$='apple'] {
+    color: #3d3d3d;
+  }
+`;
+
+const AccountButton = styled(Button)`
+  font-size: 16px;
+  height: 52px;
+`;
+
+export default SocialBtnGroup;

--- a/src/components/AccountContainer/components/TextLink.js
+++ b/src/components/AccountContainer/components/TextLink.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import styled from 'styled-components';
+
+function TextLink({ type, children }) {
+  return (
+    <Container>
+      {type.desc}
+      <Link to={`/${type.url}`}>{type.link}</Link>
+      {children}
+    </Container>
+  );
+}
+
+const Container = styled.div`
+  ${({ theme }) => theme.flexSet()};
+  font-size: 13px;
+  line-height: 20px;
+  letter-spacing: -0.015em;
+  margin: 20px 0px 0px;
+  color: rgb(109, 109, 109);
+  & a {
+    margin-left: 0.5rem;
+  }
+`;
+
+export default TextLink;

--- a/src/components/AccountContainer/components/Title.js
+++ b/src/components/AccountContainer/components/Title.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import styled from 'styled-components';
+
+function Title({ title }) {
+  return <StyledTitle>{title}</StyledTitle>;
+}
+
+const StyledTitle = styled.h1`
+  margin: 0px 0px 32px;
+  font-size: 24px;
+  font-weight: 700;
+  line-height: 36px;
+  letter-spacing: -0.025em;
+  text-align: left;
+`;
+
+export default Title;

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -2,6 +2,29 @@ import React from 'react';
 import styled, { css } from 'styled-components';
 import { darken } from 'polished';
 
+function Button({
+  children,
+  color = 'white',
+  size = 'medium',
+  fontWeight = '400',
+  fullWidth,
+  outline,
+  ...rest
+}) {
+  return (
+    <StyledButton
+      color={color}
+      size={size}
+      outline={outline}
+      fullWidth={fullWidth}
+      fontWeight={fontWeight}
+      {...rest}
+    >
+      {children}
+    </StyledButton>
+  );
+}
+
 const colorStyles = css`
   ${({ theme, color }) => {
     const selected = theme.colors[color];
@@ -75,7 +98,7 @@ const StyledButton = styled.button`
   border: 1px solid rgb(230, 230, 230);
   border-radius: 4px;
   color: black;
-  cursor: pointer;
+  cursor: url('/images/spoon.png') 20 20, auto;
   padding-left: 1rem;
   padding-right: 1rem;
   margin-bottom: 0.6rem;
@@ -88,34 +111,5 @@ const StyledButton = styled.button`
 
   ${fullWidthStyle}
 `;
-
-function Button({
-  children,
-  color,
-  size,
-  fontWeight,
-  fullWidth,
-  outline,
-  ...rest
-}) {
-  return (
-    <StyledButton
-      color={color}
-      size={size}
-      outline={outline}
-      fullWidth={fullWidth}
-      fontWeight={fontWeight}
-      {...rest}
-    >
-      {children}
-    </StyledButton>
-  );
-}
-
-Button.defaultProps = {
-  color: 'white',
-  size: 'medium',
-  fontWeight: '400',
-};
 
 export default Button;

--- a/src/components/Nav/Nav.js
+++ b/src/components/Nav/Nav.js
@@ -1,13 +1,44 @@
-import React from 'react';
-import styled from 'styled-components/macro';
+import React, { useState, useEffect } from 'react';
+import styled, { css } from 'styled-components/macro';
 import { Link, useLocation } from 'react-router-dom';
+import { API } from '../../config';
 
 function Nav() {
   const location = useLocation();
+  const [user, setUser] = useState('');
+  const [isShow, setIsShow] = useState(false);
+
+  const showMenu = () => {
+    setIsShow(prevState => !prevState);
+  };
+
+  const handleLogout = () => {
+    alert('로그아웃 되었습니다.');
+    localStorage.clear();
+  };
+
+  const getUserInfo = () => {
+    !!isLogin &&
+      fetch(`${API.USER}`, {
+        headers: { Authorization: localStorage.getItem('token') },
+      })
+        .then(res => res.json())
+        .then(res => {
+          res.status === 'SUCCESS' && setUser(res.data.user);
+        });
+  };
+
+  const isPathNameMain = location.pathname === '/';
+  const isPathNameMe = location.pathname === '/me';
+  const isLogin = !!localStorage.getItem('token');
+
+  useEffect(() => {
+    getUserInfo();
+  }, [isLogin]);
 
   return (
     <Container>
-      {location.pathname === '/' && (
+      {(isPathNameMain || isPathNameMe) && (
         <LinkGroup>
           <Link to="/">
             <i className="fas fa-bars" />
@@ -19,20 +50,99 @@ function Nav() {
       <Link to="/">
         <Logo alt="logo" src="/images/logo.png" />
       </Link>
-      {location.pathname === '/' && (
+      {(isPathNameMain || isPathNameMe) && (
         <SearchAndLogin>
           <button type="button">
             <i className="fas fa-search" />
           </button>
-          <Link to="/signin">
-            <span>로그인 / 회원가입</span>
-            <UserProfile />
-          </Link>
+          {!isLogin ? (
+            <Link to="/signin">
+              <span>로그인 / 회원가입</span>
+              <UserProfile />
+            </Link>
+          ) : (
+            <Link to="/me">
+              <span>{user.username}님</span>
+              {!!user.profile_image_url ? (
+                <UserProfile
+                  alt="profile"
+                  src={user.profile_image_url}
+                  onMouseEnter={showMenu}
+                />
+              ) : (
+                <UserProfile onMouseEnter={showMenu} />
+              )}
+            </Link>
+          )}
+          <ToggleMenu isShow={isShow} onMouseLeave={showMenu}>
+            <MenuWrapper>
+              <li>
+                <Link to="/me">🍄 마이페이지</Link>
+              </li>
+              <li onClick={handleLogout}>👋 로그아웃</li>
+            </MenuWrapper>
+          </ToggleMenu>
         </SearchAndLogin>
       )}
     </Container>
   );
 }
+
+const ToggleMenu = styled.div`
+  ${props =>
+    props.isShow
+      ? css`
+          display: block;
+        `
+      : css`
+          display: none;
+        `};
+  position: absolute;
+  right: 10px;
+  top: 40px;
+  background-color: ${({ theme }) => theme.colors.black};
+  color: white;
+  border-radius: 4px;
+
+  ${({ theme }) => theme.desktop`
+    top:50px
+`};
+`;
+
+const MenuWrapper = styled.ul`
+  ${({ theme }) => theme.flexColumnSet()};
+  & > li {
+    margin: 1rem;
+    cursor: pointer;
+    display: block;
+    width: 78px;
+    text-align: center;
+
+    ${({ theme }) => theme.desktop`
+      width: 100px;
+    `};
+
+    &:last-of-type {
+      margin-top: 0;
+    }
+  }
+
+  & a {
+    color: white;
+  }
+
+  &:after {
+    content: '';
+    position: absolute;
+    bottom: 100%;
+    left: 80%;
+    margin-left: -5px;
+    border-width: 5px;
+    border-style: solid;
+    border-color: transparent transparent ${({ theme }) => theme.colors.black}
+      transparent;
+  }
+`;
 
 const Container = styled.div`
   ${({ theme }) => theme.flexSet('space-between')};
@@ -85,6 +195,7 @@ const LinkGroup = styled.div`
 
 const Logo = styled.img`
   width: 70px;
+  cursor: url('/images/face.png') 20 20, auto;
   ${({ theme }) => theme.posCenter()};
   ${({ theme }) => theme.desktop`
     width: 85px;
@@ -92,6 +203,7 @@ const Logo = styled.img`
 `;
 
 const SearchAndLogin = styled.div`
+  position: relative;
   ${({ theme }) => theme.flexSet('flex-end')}
   & button {
     padding: 5px;
@@ -116,7 +228,7 @@ const SearchAndLogin = styled.div`
   }
 `;
 
-const UserProfile = styled.div`
+const UserProfile = styled.img`
   display: inline-block;
   width: 28px;
   height: 28px;

--- a/src/config.js
+++ b/src/config.js
@@ -1,2 +1,8 @@
-const IP = '';
-export const API = {};
+const HOST = 'http://api.tteokbok.com';
+
+export const API = {
+  SIGNIN: `${HOST}/users/signin`,
+  SIGNUP: `${HOST}/users/signup`,
+  KAKAO: `${HOST}/users/signin/kakao`,
+  USER: `${HOST}/users/me`,
+};

--- a/src/pages/Join/CreateAccount.js
+++ b/src/pages/Join/CreateAccount.js
@@ -1,0 +1,259 @@
+import React, { useState } from 'react';
+import Container from '../../components/AccountContainer/components/Container';
+import SocialBtnGroup from '../../components/AccountContainer/components/SocialBtnGroup';
+import Title from '../../components/AccountContainer/components/Title';
+import Input from '../../components/AccountContainer/components/Input';
+import styled from 'styled-components/macro';
+import Button from '../../components/Button/Button';
+import Divider from '../../components/AccountContainer/components/Divider';
+import { Link, useHistory } from 'react-router-dom';
+import Section from '../../components/AccountContainer/components/Section';
+import { API } from '../../config';
+
+function CreateAccount() {
+  const history = useHistory();
+  const [inputs, setInputs] = useState({
+    username: '',
+    email: '',
+    password: '',
+  });
+  const [secondaryInput, setSecondaryInput] = useState({
+    secondaryEmail: '',
+    secondaryPassword: '',
+  });
+  const [isChecks, setIsChecks] = useState({
+    all: false,
+    check1: false,
+    check2: false,
+    check3: false,
+    check4: false,
+  });
+
+  const handleTextInput = e => {
+    const { name, value } = e.target;
+    setInputs({
+      ...inputs,
+      [name]: value,
+    });
+  };
+
+  const handleSecondaryInput = e => {
+    const { name, value } = e.target;
+    setSecondaryInput({
+      ...secondaryInput,
+      [name]: value,
+    });
+  };
+
+  const handleCheckInput = e => {
+    const { name, checked } = e.target;
+    setIsChecks({
+      ...isChecks,
+      [name]: checked,
+    });
+  };
+
+  const allCheck = () => {
+    const { check1, check2, check3 } = isChecks;
+    const isChecked = check1 && check2 && check3;
+    if (!isChecked) {
+      setIsChecks({
+        check1: true,
+        check2: true,
+        check3: true,
+        check4: true,
+      });
+    } else if (!check1 || !check2 || !check3) {
+      setIsChecks({
+        ...isChecks,
+        all: false,
+      });
+    } else {
+      setIsChecks({
+        check1: false,
+        check2: false,
+        check3: false,
+        check4: false,
+      });
+    }
+  };
+
+  const handleSignUp = () => {
+    if (username && email && password && isEqual && isChecked) {
+      fetch(`${API.SIGNUP}`, {
+        method: 'POST',
+        body: JSON.stringify({
+          username,
+          email,
+          password,
+        }),
+      })
+        .then(res => res.json())
+        .then(res => {
+          if (res.status === 'SUCCESS') {
+            alert('회원가입 성공했습니다.');
+            history.push('/signin');
+          } else if (res.status === 'DUPLICATED_ENTRY_ERROR') {
+            alert('이미 가입된 이메일입니다.');
+          } else if (res.status === 'INVALID_DATA_ERROR') {
+            alert('형식을 확인해주세요.');
+          }
+        });
+    }
+  };
+
+  const { username, email, password } = inputs;
+  const { secondaryEmail, secondaryPassword } = secondaryInput;
+  const { check1, check2, check3, check4 } = isChecks;
+  const isEqual = email === secondaryEmail && password === secondaryPassword;
+  const isChecked = check1 && check2 && check3;
+
+  return (
+    <Container>
+      <Styledform>
+        <Title title="이메일로 가입하기" />
+        <Section title="이름" input>
+          <Input
+            value={username}
+            name="username"
+            onChange={handleTextInput}
+            type="text"
+            placeholder="사용하실 이름을 입력해주세요."
+          />
+        </Section>
+        <Section title="이메일 주소" input>
+          <Input
+            value={email}
+            name="email"
+            onChange={handleTextInput}
+            type="email"
+            placeholder="이메일 주소를 입력해주세요."
+          />
+          <Input
+            value={secondaryEmail}
+            name="secondaryEmail"
+            onChange={handleSecondaryInput}
+            type="email"
+            placeholder="이메일 주소를 입력해주세요."
+          />
+          {email !== secondaryEmail && (
+            <ErrorMsg>이메일이 일치하지 않습니다.</ErrorMsg>
+          )}
+        </Section>
+        <Section title="비밀번호" input>
+          <Input
+            value={password}
+            name="password"
+            onChange={handleTextInput}
+            type="password"
+            placeholder="비밀번호를 입력해주세요."
+          />
+          <Input
+            value={secondaryPassword}
+            name="secondaryPassword"
+            onChange={handleSecondaryInput}
+            type="password"
+            placeholder="비밀번호를 입력해주세요."
+          />
+          {password !== secondaryPassword && (
+            <ErrorMsg>비밀번호가 일치하지 않습니다.</ErrorMsg>
+          )}
+        </Section>
+        <Section title="전체동의" checkbox>
+          <Input
+            name="all"
+            type="checkbox"
+            onChange={allCheck}
+            checked={isChecked}
+          />
+        </Section>
+        <StyledHr />
+        <Section title="텀블벅 이용 약관동의" checkbox>
+          <Input
+            name="check1"
+            onChange={handleCheckInput}
+            type="checkbox"
+            checked={check1}
+          />
+        </Section>
+        <Section title="개인정보 수집, 이용 동의" checkbox>
+          <Input
+            name="check2"
+            onChange={handleCheckInput}
+            type="checkbox"
+            checked={check2}
+          />
+        </Section>
+        <Section title="만 14세 이상입니다." checkbox>
+          <Input
+            name="check3"
+            onChange={handleCheckInput}
+            type="checkbox"
+            checked={check3}
+          />
+        </Section>
+        <Section title="마케팅 정보 수집 동의(선택)" checkbox>
+          <Input
+            name="check4"
+            onChange={handleCheckInput}
+            type="checkbox"
+            checked={check4}
+          />
+        </Section>
+        <StyledButton
+          type="button"
+          color={isEqual && isChecked ? 'red' : 'blue'}
+          fullWidth
+          disabled={!(isEqual && isChecked)}
+          onClick={handleSignUp}
+        >
+          가입하기
+        </StyledButton>
+      </Styledform>
+      <StyledLink>
+        이미 떡볶닷컴 계정이 있으신가요?
+        <Link to="/signin">기존 계정으로 로그인하기</Link>
+      </StyledLink>
+      <Divider />
+      <SocialBtnGroup text="가입하기" />
+    </Container>
+  );
+}
+
+const Styledform = styled.form`
+  font-size: 13px;
+  [type='checkbox'] {
+    width: 20px;
+    height: 20px;
+  }
+`;
+
+const ErrorMsg = styled.div`
+  font-size: 1rem;
+  color: ${({ theme }) => theme.colors.red};
+  padding-left: 4px;
+`;
+
+const StyledButton = styled(Button)`
+  height: 52px;
+`;
+
+const StyledHr = styled.div`
+  margin: 0 0 1rem 0px;
+  border-bottom: 0.5px solid ${({ theme }) => theme.colors.border}; ;
+`;
+
+const StyledLink = styled.div`
+  ${({ theme }) => theme.flexColumnSet()};
+  font-size: 13px;
+  line-height: 20px;
+  letter-spacing: -0.015em;
+  margin: 20px 0px 0px;
+  color: rgb(109, 109, 109);
+
+  & a {
+    margin-left: 0.5rem;
+  }
+`;
+
+export default CreateAccount;

--- a/src/pages/Join/Join.js
+++ b/src/pages/Join/Join.js
@@ -1,6 +1,34 @@
 import React from 'react';
+import styled from 'styled-components/macro';
+import AccountContainer from '../../components/AccountContainer/AccountContainer';
+import Button from '../../components/Button/Button';
+import { useHistory } from 'react-router-dom';
 
 function Join() {
-  return <></>;
+  const history = useHistory();
+
+  const handleClick = () => {
+    history.push('/createAccount');
+  };
+
+  return (
+    <AccountContainer type="signin">
+      <EmailBtn fullWidth onClick={handleClick}>
+        <i className="far fa-envelope"></i>
+        이메일로 가입하기
+      </EmailBtn>
+    </AccountContainer>
+  );
 }
+
+const EmailBtn = styled(Button)`
+  height: 52px;
+
+  i {
+    margin-right: 6px;
+    font-size: 20px;
+    color: ${({ theme }) => theme.colors.secondaryGray};
+  }
+`;
+
 export default Join;

--- a/src/pages/Login/Login.js
+++ b/src/pages/Login/Login.js
@@ -1,7 +1,94 @@
-import React from 'react';
+import React, { useState } from 'react';
+import AccountContainer from '../../components/AccountContainer/AccountContainer';
+import Button from '../../components/Button/Button';
+import styled from 'styled-components';
+import { API } from '../../config';
+import { useHistory } from 'react-router-dom';
+import Input from '../../components/AccountContainer/components/Input';
 
-function Login() {
-  return <></>;
+function Login(props) {
+  const history = useHistory();
+  const [inputs, setInputs] = useState({
+    email: '',
+    password: '',
+  });
+
+  const handleInput = e => {
+    const { name, value } = e.target;
+    setInputs({
+      ...inputs,
+      [name]: value,
+    });
+  };
+
+  const handelLogin = e => {
+    e.preventDefault();
+    const { email, password } = inputs;
+    if (isValid) {
+      fetch(`${API.SIGNIN}`, {
+        method: 'POST',
+        body: JSON.stringify({
+          email,
+          password,
+        }),
+      })
+        .then(res => res.json())
+        .then(res => {
+          if (res.status === 'SUCCESS') {
+            alert('로그인 되었습니다.');
+            localStorage.setItem('token', res.data.token);
+            history.push('/');
+          } else if (res.status === 'INVALID_USER_ERROR') {
+            alert('가입되지 않은 유저입니다.');
+          } else if (res.status === 'UNAUTHORIZATION_ERROR') {
+            alert('비밀번호가 일치하지 않습니다.');
+          }
+        });
+    } else {
+      alert('이메일 주소 또는 비밀번호를 확인해주세요.');
+    }
+  };
+
+  const { email, password } = inputs;
+  const isValid = email.includes('@', '.') && password.length >= 8;
+  return (
+    <AccountContainer type="signup">
+      <form>
+        <Input
+          value={email}
+          name="email"
+          onChange={handleInput}
+          type="text"
+          autocomplete="email"
+          autocapitalize="off"
+          placeholder="이메일 주소 입력"
+        />
+        <Input
+          value={password}
+          name="password"
+          type="password"
+          autocomplete="current-password"
+          autocapitalize="off"
+          onChange={handleInput}
+          placeholder="비밀번호 입력"
+        />
+        <StyledButton
+          onClick={handelLogin}
+          color="red"
+          fontWeight="700"
+          disabled={!isValid}
+          fullWidth
+        >
+          로그인
+        </StyledButton>
+      </form>
+    </AccountContainer>
+  );
 }
+
+const StyledButton = styled(Button)`
+  height: 52px;
+  font-size: 16px;
+`;
 
 export default Login;

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -41,7 +41,7 @@ const posCenter = (type = 'absolute') => {
 const colors = {
   red: '#f26462',
   white: '#FFF',
-  blue: '#3A6FF2',
+  blue: '#3a6ff2',
   black: 'rgb(61, 61, 61)',
   primaryGray: '#3f4150',
   secondaryGray: '#8c8d96',


### PR DESCRIPTION
>wecode PR message template 및 체크 리스트 입니다. 
아래 사항들을 전부 작성/체크 하시고 PR 해주세요!

## 수정 사항 간략한 한줄 요약
(여기에 수정 사항에 대한 간략한 한줄 요약/제목 작성해 주세요.)
- 소셜 로그인 구현 :  카카오
- 이메일 로그인 구현
- 이메일 회원가입 구현
- 로그아웃 구현
- 로그인 시 헤더에 유저정보 표시하기
- 로그인 후 프로필 호버 시 메뉴 나타남
		 
## 수정 사항들 자세한 내용
(여기에 수정 사항에 대한 자세한 내용을 작성해 주세요.)
[CreateAccount]
- 비밀번호 및 이메일 더블 체크 : 다를 경우 에러 메세지 
- 체크 박스 : 전체 선택 체크 박스 및 필수, 선택사항 
*isSignUpOrIsSignIn
- 이름을 textlink로 수정하고, type을 인자로 받을 수 있음(signin or signup)

## 기타 질문 및 특이 사항
### 1번
![update?](https://user-images.githubusercontent.com/77728308/120125044-f8c6f680-c1f1-11eb-883b-d592aa4e7ff3.gif)
<img width="466" alt="스크린샷 2021-05-31 오전 9 26 05" src="https://user-images.githubusercontent.com/77728308/120125096-3af03800-c1f2-11eb-9e95-9352c2a7fee0.png">
- 여기서 isLogin은 `localStorage.getItem('token')`입니다.
- 이메일로 로그인하고 로그아웃할때는 프로필 이미지가 의도대로 나타나는데(백그라운드만 보이는 것), 카카오톡으로 로그인 후 로그아웃하면 프로필 이미지가 위의 모습처럼 나타납니다.
- 새로고침을 하면 사라지긴하는데 어떻게 하면 새로고침을 하지 않고도 로그아웃 후에 백그라운드만 보일 수 있을까요?
- 우선 isLogin을 state에 넣어서 관리하려고 해보았는데 실패했습니다..!
- 그리고 이미지 로딩 실패 시 나타나는 네모?가 보기 싫어서 이런 식으로 경우의 수를 나누었는데  이미지 태그가 alt, src가 없어도 될까요??

### 2번 😭😭😭😭😭😭😭😭😭😭
- 무한루프에서 어떻게 벗어나야할지 모르겠습니다..
- 특히 이해가 되지 않는 부분은, 의존성배열에 넣을 수 있는 값입니다.
<img width="872" alt="스크린샷 2021-05-31 오전 9 36 58" src="https://user-images.githubusercontent.com/77728308/120125446-ccac7500-c1f3-11eb-8c6c-8bc60f112995.png">
이 글에서 dependency에 넣는 값은 값이 변할 경우에만 effect를 실행할 수 있다고 하는데, 제가 쓴 코드에서는 특정 state만 넣어도 미친듯이 업데이트가 됩니다.. 
- 다른 계정으로 로그인 할 경우 유저 정보를 업데이트하고 싶어서 useEffect 두번째 인자로 유저정보를 담고 있는 user라는 state를 넣어보았습니다. 그런데!! 다른 계정으로 로그인하지 않았는데도 계속 effect가 실행됩니다.
- state가 비어있다가 새로운 정보가 들어가서 업데이트가 되는 건가 싶다가도,, 모든 state는 변하는 값이고 당연히 fetch하면 값이 달라지는 건데.. 라는 생각에 이해도 안되고 뭐가 문제인지 잘 모르겠습니다..
- 아니면 전부 prevState랑 비교하도록 조건을 걸어줘야할까요?? 
- 그리고 의존성배열에 넣을 값을 vscode가 추천해주기도 하는데, 그 값을 넣어도 무한루프만 발생됩니다..
<img width="713" alt="스크린샷 2021-05-31 오전 9 48 13" src="https://user-images.githubusercontent.com/77728308/120125896-6b85a100-c1f5-11eb-97c7-1d1a9a5f4128.png">
- 제가 뭔가 엄청 잘못이해하고 있는 것 같은데,, 도저히 모르겠습니다..ㅠ.ㅠㅜㅠㅜㅠㅜㅠ

### 3번
<img width="759" alt="스크린샷 2021-05-30 오후 12 23 00" src="https://user-images.githubusercontent.com/77728308/120125969-ac7db580-c1f5-11eb-89d9-3fbe288f7f04.png">
- url에 아이디 비밀번호가 노출되는데 이걸 막을 방법이 있을까요??
- 전 보안도 취약하고 성능도 굉장히 안좋은 코드만 작성하는 것 같아요ㅕ..ㅎㅎㅠㅎ

### 4번 
- 카카오 로그인 후 로그아웃할때 로컬에 있는 쿠키가 삭제가 되지않아 수동으로 방문기록을 삭제해야만 다른 계정으로 로그인이 가능합니다.
<img width="473" alt="스크린샷 2021-05-29 오후 6 46 48" src="https://user-images.githubusercontent.com/77728308/120126092-1dbd6880-c1f6-11eb-8622-0e5c1b1bae21.png">
- 노란 박스 부분에서 kakao는 삭제가 되는데, local만 안 지워집니다 ㅠㅠ
- react-cookie도 설치해보고, Universal-cookie로 사용해보았느데 실패했습니다. 
- stack over flow에 나온 방법도 따라해보았느는데 실패했습니다..
<img width="751" alt="스크린샷 2021-05-30 오전 11 07 46" src="https://user-images.githubusercontent.com/77728308/120126349-f31fdf80-c1f6-11eb-8ff8-2c69254c723a.png">
<img width="751" alt="스크린샷 2021-05-30 오전 11 07 46" src="https://user-images.githubusercontent.com/77728308/120126362-fe730b00-c1f6-11eb-812f-ac4070892361.png">
0- 다른 방법이 있을까요??






## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge가 됩니다!)
- [x] 필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x] Wecode의 코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x] 제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x] 본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.
- [x] Git rebase와 squash를 했고 커밋 수가 하나 인것을 확인 했습니다.
>wecode PR message template 및 체크 리스트 입니다. 
아래 사항들을 전부 작성/체크 하시고 PR 해주세요!

